### PR TITLE
[codex] Add IMM command execution to bot

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,3 +2,7 @@ DISCORD_TOKEN=your_discord_bot_token_here
 DATABASE_URL=postgres://user:password@localhost/nkmzbot
 API_URL=https://api.example.com
 API_TOKEN=your_api_token_here
+IMM_BINARY=imm
+IMM_TIMEOUT_MS=3000
+IMM_MAX_SOURCE_BYTES=65536
+IMM_MAX_OUTPUT_BYTES=65536

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Discord bot for managing custom commands.
 - DATABASE_URL: Postgres 接続文字列
 - API_URL: カスタムコマンド管理APIのURL
 - API_TOKEN: カスタムコマンド管理APIのトークン
+- IMM_BINARY: IMM CLIのパス（省略時 `imm`）
+- IMM_TIMEOUT_MS: IMM実行タイムアウトms（省略時 `3000`）
+- IMM_MAX_SOURCE_BYTES: IMMソース上限（省略時 `65536`）
+- IMM_MAX_OUTPUT_BYTES: IMM出力上限（省略時 `65536`）
 
 ## 起動方法(ローカル)
 
@@ -49,6 +53,9 @@ go build -o nkmzbot cmd/nkmzbot/main.go
   - `name`: コマンド名
 - `/list` - 登録されているコマンド一覧を表示
 - `/ramdom` - 登録されているコマンドからランダムに1つ返答
+- `/imm run` - IMMコードをその場で実行
+- `/imm check` - IMMコードを構文チェック
+- `/imm command add|update|remove` - IMMカスタムコマンドを管理
 
 ### その他のコマンド
 - `/jikan` - スケジュール実行を管理
@@ -56,6 +63,7 @@ go build -o nkmzbot cmd/nkmzbot/main.go
 - `/guess` - ジオゲッサーを開始・プレイ
 - `/wallet` - Wallet API を使って送金・請求を記録
 - `Register as Response` - メッセージコンテキストメニュー（メッセージを右クリックしてコマンドとして登録）
+- `Run as IMM` - メッセージコンテキストメニュー（メッセージ本文をIMMとして実行）
 
 `/wallet` は以下のサブコマンドを提供します。
 
@@ -64,4 +72,4 @@ go build -o nkmzbot cmd/nkmzbot/main.go
 
 Wallet API への呼び出しでは既存の `API_TOKEN` を使い、操作ユーザーの Discord ID を `X-Discord-User-ID` ヘッダーで渡します。バックエンド側で Discord ID から Wallet 利用者を特定できる必要があります。
 
-登録したコマンドは `!コマンド名` で呼び出せます。
+登録したコマンドは `!コマンド名` で呼び出せます。IMMコマンドは `!コマンド名 引数...` の形で引数を渡せます。IMM側では `bot_args`、`bot_raw`、`bot_user_id`、`bot_channel_id`、`bot_guild_id` を参照できます。

--- a/cmd/nkmzbot/main.go
+++ b/cmd/nkmzbot/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/susu3304/nkmzbot/internal/bot"
 	"github.com/susu3304/nkmzbot/internal/config"
 	"github.com/susu3304/nkmzbot/internal/db"
+	"github.com/susu3304/nkmzbot/internal/imm"
 )
 
 func main() {
@@ -31,8 +32,13 @@ func main() {
 		log.Fatalf("Failed to run migrations: %v", err)
 	}
 
+	immRunner := imm.NewRunner(cfg.IMMBinaryPath)
+	immRunner.Timeout = cfg.IMMTimeout
+	immRunner.MaxSourceBytes = cfg.IMMMaxSourceBytes
+	immRunner.MaxOutputBytes = cfg.IMMMaxOutputBytes
+
 	// Initialize Discord bot
-	discordBot, err := bot.New(cfg.DiscordToken, cfg.APIURL, cfg.APIToken, database)
+	discordBot, err := bot.New(cfg.DiscordToken, cfg.APIURL, cfg.APIToken, database, immRunner)
 	if err != nil {
 		log.Fatalf("Failed to create discord bot: %v", err)
 	}

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -13,6 +13,7 @@ import (
 	"github.com/susu3304/nkmzbot/internal/commands"
 	"github.com/susu3304/nkmzbot/internal/db"
 	"github.com/susu3304/nkmzbot/internal/guess"
+	"github.com/susu3304/nkmzbot/internal/imm"
 	"github.com/susu3304/nkmzbot/internal/nomikai"
 )
 
@@ -20,13 +21,14 @@ type Bot struct {
 	session         *discordgo.Session
 	db              *db.DB
 	client          *client.Client
+	immRunner       *imm.Runner
 	nomikai         *nomikai.Service
 	guess           *guess.Service
 	reminder        *reminderWorker
 	schedulerCancel context.CancelFunc
 }
 
-func New(token, apiURL, apiToken string, database *db.DB) (*Bot, error) {
+func New(token, apiURL, apiToken string, database *db.DB, immRunner *imm.Runner) (*Bot, error) {
 	session, err := discordgo.New("Bot " + token)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create discord session: %w", err)
@@ -53,11 +55,12 @@ func New(token, apiURL, apiToken string, database *db.DB) (*Bot, error) {
 	}
 
 	bot := &Bot{
-		session: session,
-		db:      database,
-		client:  client.New(apiURL, apiToken),
-		nomikai: nomikai.NewService(database),
-		guess:   guess.NewService(database),
+		session:   session,
+		db:        database,
+		client:    client.New(apiURL, apiToken),
+		immRunner: immRunner,
+		nomikai:   nomikai.NewService(database),
+		guess:     guess.NewService(database),
 	}
 	bot.reminder = newReminderWorker(session, database, bot.nomikai)
 

--- a/internal/bot/events.go
+++ b/internal/bot/events.go
@@ -6,10 +6,13 @@ import (
 	"log"
 	"strconv"
 	"strings"
+	"time"
+	"unicode"
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/susu3304/nkmzbot/internal/client"
 	"github.com/susu3304/nkmzbot/internal/commands"
+	"github.com/susu3304/nkmzbot/internal/imm"
 )
 
 func (b *Bot) onReady(s *discordgo.Session, event *discordgo.Ready) {
@@ -50,22 +53,92 @@ func (b *Bot) onMessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) 
 
 	content := strings.TrimSpace(m.Content)
 	if strings.HasPrefix(content, "!") && len(content) > 1 {
-		cmdName := content[1:]
+		commandText := strings.TrimSpace(content[1:])
 		if m.GuildID != "" {
-			resp, err := b.client.GetCommandResponse(m.GuildID, cmdName)
-			if err == nil && resp != "" {
-				if _, err := s.ChannelMessageSend(m.ChannelID, resp); err == nil {
-					go func() {
-						_ = b.client.RecordCommandUsage(m.GuildID, cmdName, client.CommandUsageInput{
-							ActorID:   m.Author.ID,
-							ChannelID: m.ChannelID,
-							Source:    "bot-message",
-						})
-					}()
-				}
-			}
+			b.handleCustomCommandMessage(s, m, commandText)
 		}
 	}
+}
+
+func (b *Bot) handleCustomCommandMessage(s *discordgo.Session, m *discordgo.MessageCreate, commandText string) {
+	cmdName, cmd, rawArgs, args, err := b.lookupMessageCommand(m.GuildID, commandText)
+	if err != nil || cmd == nil {
+		return
+	}
+
+	response := cmd.Response
+	if strings.EqualFold(cmd.Kind, "imm") {
+		response = b.runImmCommandForMessage(m, cmd.Response, rawArgs, args)
+	}
+	if strings.TrimSpace(response) == "" {
+		return
+	}
+
+	if _, err := s.ChannelMessageSend(m.ChannelID, response); err == nil {
+		go func() {
+			_ = b.client.RecordCommandUsage(m.GuildID, cmdName, client.CommandUsageInput{
+				ActorID:   m.Author.ID,
+				ChannelID: m.ChannelID,
+				Source:    "bot-message",
+			})
+		}()
+	}
+}
+
+func (b *Bot) lookupMessageCommand(guildID, commandText string) (string, *client.BotCommandResponse, string, []string, error) {
+	cmd, err := b.client.GetCommand(guildID, commandText)
+	if err != nil {
+		return "", nil, "", nil, err
+	}
+	if cmd != nil {
+		return commandText, cmd, "", nil, nil
+	}
+
+	name, rawArgs := splitCommandText(commandText)
+	if name == "" || name == commandText {
+		return "", nil, "", nil, nil
+	}
+	cmd, err = b.client.GetCommand(guildID, name)
+	if err != nil || cmd == nil {
+		return "", nil, "", nil, err
+	}
+	args, err := imm.SplitArgs(rawArgs)
+	if err != nil {
+		return "", nil, "", nil, err
+	}
+	return name, cmd, rawArgs, args, nil
+}
+
+func splitCommandText(commandText string) (string, string) {
+	commandText = strings.TrimSpace(commandText)
+	idx := strings.IndexFunc(commandText, unicode.IsSpace)
+	if idx < 0 {
+		return commandText, ""
+	}
+	return commandText[:idx], strings.TrimSpace(commandText[idx:])
+}
+
+func (b *Bot) runImmCommandForMessage(m *discordgo.MessageCreate, source, rawArgs string, args []string) string {
+	if b.immRunner == nil {
+		return "IMM runner is not configured."
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), b.immRunner.Timeout+time.Second)
+	defer cancel()
+	result, err := b.immRunner.Run(ctx, imm.Request{
+		Source:    source,
+		Args:      args,
+		RawArgs:   rawArgs,
+		UserID:    m.Author.ID,
+		ChannelID: m.ChannelID,
+		GuildID:   m.GuildID,
+	})
+	if err != nil {
+		return "IMM実行に失敗しました: " + err.Error()
+	}
+	if result.ExitCode != 0 || result.TimedOut || result.OutputTruncated {
+		return commands.FormatImmFailure("IMM実行に失敗しました", result)
+	}
+	return commands.FormatImmOutput(result.Stdout)
 }
 
 func (b *Bot) onInteractionCreate(s *discordgo.Session, i *discordgo.InteractionCreate) {
@@ -179,8 +252,12 @@ func (b *Bot) handleApplicationCommand(s *discordgo.Session, i *discordgo.Intera
 		commands.HandleWallet(s, i, b.client)
 	case "jikan":
 		commands.HandleJikan(s, i, b.nomikai, b.db, b.client)
+	case "imm":
+		commands.HandleImm(s, i, b.client, b.immRunner)
 	case "Register as Response":
 		commands.HandleRegisterAsResponse(s, i)
+	case "Run as IMM":
+		commands.HandleRunMessageAsIMM(s, i, b.immRunner)
 	}
 }
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -112,6 +112,7 @@ func expectStatus(resp *http.Response, allowed ...int) error {
 type CommandRecord struct {
 	GuildID   string   `json:"guildId"`
 	Name      string   `json:"name"`
+	Kind      string   `json:"kind"`
 	Response  string   `json:"response"`
 	Tags      []string `json:"tags,omitempty"`
 	CreatedAt string   `json:"createdAt"`
@@ -123,38 +124,59 @@ type CommandsListResponse struct {
 
 type BotCommandResponse struct {
 	Response string `json:"response"`
+	Kind     string `json:"kind"`
 }
 
 func (c *Client) GetCommandResponse(guildID, name string) (string, error) {
-	resp, err := c.doRequest("GET", fmt.Sprintf("/bot/guilds/%s/commands/%s", guildID, name), nil)
+	cmdResp, err := c.GetCommand(guildID, name)
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNotFound {
-		return "", nil // Or custom error
-	}
-	if err := expectStatus(resp, http.StatusOK); err != nil {
-		return "", err
-	}
-
-	var cmdResp BotCommandResponse
-	if err := json.NewDecoder(resp.Body).Decode(&cmdResp); err != nil {
-		return "", err
+	if cmdResp == nil {
+		return "", nil
 	}
 	return cmdResp.Response, nil
 }
 
+func (c *Client) GetCommand(guildID, name string) (*BotCommandResponse, error) {
+	resp, err := c.doRequest("GET", fmt.Sprintf("/bot/guilds/%s/commands/%s", url.PathEscape(guildID), url.PathEscape(name)), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, nil
+	}
+	if err := expectStatus(resp, http.StatusOK); err != nil {
+		return nil, err
+	}
+
+	var cmdResp BotCommandResponse
+	if err := json.NewDecoder(resp.Body).Decode(&cmdResp); err != nil {
+		return nil, err
+	}
+	if cmdResp.Kind == "" {
+		cmdResp.Kind = "text"
+	}
+	return &cmdResp, nil
+}
+
 type commandWriteRequest struct {
 	Name     string   `json:"name"`
+	Kind     string   `json:"kind,omitempty"`
 	Response string   `json:"response"`
 	Tags     []string `json:"tags,omitempty"`
 }
 
 func (c *Client) AddCommand(guildID, name, response string, tags ...string) error {
+	return c.AddCommandWithKind(guildID, name, response, "text", tags...)
+}
+
+func (c *Client) AddCommandWithKind(guildID, name, response, kind string, tags ...string) error {
 	body := commandWriteRequest{
 		Name:     name,
+		Kind:     kind,
 		Response: response,
 		Tags:     normalizeTags(tags),
 	}
@@ -187,8 +209,13 @@ func (c *Client) RemoveCommand(guildID, name string) error {
 }
 
 func (c *Client) UpdateCommand(guildID, name, response string, tags ...string) error {
+	return c.UpdateCommandWithKind(guildID, name, response, "text", tags...)
+}
+
+func (c *Client) UpdateCommandWithKind(guildID, name, response, kind string, tags ...string) error {
 	body := commandWriteRequest{
 		Name:     name,
+		Kind:     kind,
 		Response: response,
 		Tags:     normalizeTags(tags),
 	}

--- a/internal/commands/definitions.go
+++ b/internal/commands/definitions.go
@@ -3,7 +3,121 @@ package commands
 import "github.com/bwmarrin/discordgo"
 
 func GetCommands() []*discordgo.ApplicationCommand {
+	sourceMaxLength := 4000
 	return []*discordgo.ApplicationCommand{
+		{
+			Name:         "imm",
+			Description:  "IMMコードの実行とIMMカスタムコマンドを管理します",
+			DMPermission: boolPtr(false),
+			Options: []*discordgo.ApplicationCommandOption{
+				{
+					Type:        discordgo.ApplicationCommandOptionSubCommand,
+					Name:        "run",
+					Description: "IMMコードをその場で実行します",
+					Options: []*discordgo.ApplicationCommandOption{
+						{
+							Type:        discordgo.ApplicationCommandOptionString,
+							Name:        "source",
+							Description: "実行するIMMコード（コードブロック可）",
+							Required:    true,
+							MaxLength:   sourceMaxLength,
+						},
+						{
+							Type:        discordgo.ApplicationCommandOptionString,
+							Name:        "args",
+							Description: "bot_argsに渡す引数（空白区切り、引用符可）",
+							Required:    false,
+						},
+					},
+				},
+				{
+					Type:        discordgo.ApplicationCommandOptionSubCommand,
+					Name:        "check",
+					Description: "IMMコードを構文チェックします",
+					Options: []*discordgo.ApplicationCommandOption{
+						{
+							Type:        discordgo.ApplicationCommandOptionString,
+							Name:        "source",
+							Description: "チェックするIMMコード（コードブロック可）",
+							Required:    true,
+							MaxLength:   sourceMaxLength,
+						},
+					},
+				},
+				{
+					Type:        discordgo.ApplicationCommandOptionSubCommandGroup,
+					Name:        "command",
+					Description: "IMMカスタムコマンドを管理します",
+					Options: []*discordgo.ApplicationCommandOption{
+						{
+							Type:        discordgo.ApplicationCommandOptionSubCommand,
+							Name:        "add",
+							Description: "IMMカスタムコマンドを追加します",
+							Options: []*discordgo.ApplicationCommandOption{
+								{
+									Type:        discordgo.ApplicationCommandOptionString,
+									Name:        "name",
+									Description: "コマンド名（!は不要）",
+									Required:    true,
+								},
+								{
+									Type:        discordgo.ApplicationCommandOptionString,
+									Name:        "source",
+									Description: "IMMソース（bot_argsを使用できます）",
+									Required:    true,
+									MaxLength:   sourceMaxLength,
+								},
+								{
+									Type:        discordgo.ApplicationCommandOptionString,
+									Name:        "tags",
+									Description: "タグ（カンマ区切り、省略可）",
+									Required:    false,
+								},
+							},
+						},
+						{
+							Type:        discordgo.ApplicationCommandOptionSubCommand,
+							Name:        "update",
+							Description: "IMMカスタムコマンドを更新します",
+							Options: []*discordgo.ApplicationCommandOption{
+								{
+									Type:        discordgo.ApplicationCommandOptionString,
+									Name:        "name",
+									Description: "更新するコマンド名",
+									Required:    true,
+								},
+								{
+									Type:        discordgo.ApplicationCommandOptionString,
+									Name:        "source",
+									Description: "新しいIMMソース",
+									Required:    true,
+									MaxLength:   sourceMaxLength,
+								},
+								{
+									Type:        discordgo.ApplicationCommandOptionString,
+									Name:        "tags",
+									Description: "タグ（カンマ区切り、省略可）",
+									Required:    false,
+								},
+							},
+						},
+						{
+							Type:        discordgo.ApplicationCommandOptionSubCommand,
+							Name:        "remove",
+							Description: "IMMカスタムコマンドを削除します",
+							Options: []*discordgo.ApplicationCommandOption{
+								{
+									Type:        discordgo.ApplicationCommandOptionString,
+									Name:        "name",
+									Description: "削除するコマンド名",
+									Required:    true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 		{
 			Name:         "add",
 			Description:  "新しいコマンドを追加します",
@@ -411,6 +525,10 @@ func GetCommands() []*discordgo.ApplicationCommand {
 		},
 		{
 			Name: "Register as Response",
+			Type: discordgo.MessageApplicationCommand,
+		},
+		{
+			Name: "Run as IMM",
 			Type: discordgo.MessageApplicationCommand,
 		},
 	}

--- a/internal/commands/imm.go
+++ b/internal/commands/imm.go
@@ -1,0 +1,257 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/susu3304/nkmzbot/internal/client"
+	"github.com/susu3304/nkmzbot/internal/imm"
+)
+
+func HandleImm(s *discordgo.Session, i *discordgo.InteractionCreate, cli *client.Client, runner *imm.Runner) {
+	if runner == nil {
+		respondText(s, i, "IMM runner is not configured.")
+		return
+	}
+	data := i.ApplicationCommandData()
+	if len(data.Options) == 0 {
+		respondText(s, i, "サブコマンドが指定されていません。")
+		return
+	}
+
+	top := data.Options[0]
+	switch top.Name {
+	case "run":
+		source := stringOptionValue(top.Options, "source")
+		rawArgs := stringOptionValue(top.Options, "args")
+		runImmInteraction(s, i, runner, source, rawArgs, false)
+	case "check":
+		source := stringOptionValue(top.Options, "source")
+		checkImmInteraction(s, i, runner, source)
+	case "command":
+		handleImmCommandGroup(s, i, cli, runner, top)
+	default:
+		respondText(s, i, "未知のIMMサブコマンドです。")
+	}
+}
+
+func HandleRunMessageAsIMM(s *discordgo.Session, i *discordgo.InteractionCreate, runner *imm.Runner) {
+	if runner == nil {
+		respondText(s, i, "IMM runner is not configured.")
+		return
+	}
+	data := i.ApplicationCommandData()
+	if data.Resolved == nil || len(data.Resolved.Messages) == 0 {
+		respondText(s, i, "メッセージが見つかりませんでした。")
+		return
+	}
+
+	var message *discordgo.Message
+	for _, msg := range data.Resolved.Messages {
+		message = msg
+		break
+	}
+	if message == nil || strings.TrimSpace(message.Content) == "" {
+		respondText(s, i, "IMMとして実行できる本文がありません。")
+		return
+	}
+
+	runImmInteraction(s, i, runner, message.Content, "", false)
+}
+
+func handleImmCommandGroup(s *discordgo.Session, i *discordgo.InteractionCreate, cli *client.Client, runner *imm.Runner, group *discordgo.ApplicationCommandInteractionDataOption) {
+	if len(group.Options) == 0 {
+		respondText(s, i, "IMM commandのサブコマンドが指定されていません。")
+		return
+	}
+
+	sub := group.Options[0]
+	switch sub.Name {
+	case "add", "update":
+		name := strings.TrimPrefix(strings.TrimSpace(stringOptionValue(sub.Options, "name")), "!")
+		source := stringOptionValue(sub.Options, "source")
+		tags := parseTags(stringOptionValue(sub.Options, "tags"))
+		if name == "" || strings.TrimSpace(source) == "" {
+			respondText(s, i, "nameとsourceが必要です。")
+			return
+		}
+
+		if !deferInteraction(s, i) {
+			return
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), runner.Timeout+time.Second)
+		defer cancel()
+		check, err := runner.Check(ctx, immRequest(i, source, "", nil))
+		if err != nil {
+			editInteraction(s, i, "IMMチェックに失敗しました: "+err.Error())
+			return
+		}
+		if check.ExitCode != 0 || check.TimedOut || check.OutputTruncated {
+			editInteraction(s, i, FormatImmFailure("IMMチェックに失敗しました", check))
+			return
+		}
+
+		var saveErr error
+		if sub.Name == "add" {
+			saveErr = cli.AddCommandWithKind(i.GuildID, name, source, "imm", tags...)
+		} else {
+			saveErr = cli.UpdateCommandWithKind(i.GuildID, name, source, "imm", tags...)
+		}
+		if saveErr != nil {
+			if client.IsConnectionError(saveErr) {
+				editInteraction(s, i, apiConnectionErrorMessage)
+			} else {
+				editInteraction(s, i, "IMMコマンドの保存に失敗しました: "+saveErr.Error())
+			}
+			return
+		}
+		action := "追加"
+		if sub.Name == "update" {
+			action = "更新"
+		}
+		editInteraction(s, i, fmt.Sprintf("IMMコマンド `!%s` を%sしました。", name, action))
+	case "remove":
+		name := strings.TrimPrefix(strings.TrimSpace(stringOptionValue(sub.Options, "name")), "!")
+		if name == "" {
+			respondText(s, i, "nameが必要です。")
+			return
+		}
+		err := cli.RemoveCommand(i.GuildID, name)
+		if err != nil {
+			if client.IsConnectionError(err) {
+				respondText(s, i, apiConnectionErrorMessage)
+			} else {
+				respondText(s, i, "IMMコマンドの削除に失敗しました。")
+			}
+			return
+		}
+		respondText(s, i, fmt.Sprintf("IMMコマンド `!%s` を削除しました。", name))
+	default:
+		respondText(s, i, "未知のIMM commandサブコマンドです。")
+	}
+}
+
+func runImmInteraction(s *discordgo.Session, i *discordgo.InteractionCreate, runner *imm.Runner, source, rawArgs string, trace bool) {
+	args, err := imm.SplitArgs(rawArgs)
+	if err != nil {
+		respondText(s, i, "argsの解釈に失敗しました: "+err.Error())
+		return
+	}
+	if !deferInteraction(s, i) {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), runner.Timeout+time.Second)
+	defer cancel()
+	req := immRequest(i, source, rawArgs, args)
+	req.Trace = trace
+	result, err := runner.Run(ctx, req)
+	if err != nil {
+		editInteraction(s, i, "IMM実行に失敗しました: "+err.Error())
+		return
+	}
+	if result.ExitCode != 0 || result.TimedOut || result.OutputTruncated {
+		editInteraction(s, i, FormatImmFailure("IMM実行に失敗しました", result))
+		return
+	}
+	editInteraction(s, i, FormatImmOutput(result.Stdout))
+}
+
+func checkImmInteraction(s *discordgo.Session, i *discordgo.InteractionCreate, runner *imm.Runner, source string) {
+	if !deferInteraction(s, i) {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), runner.Timeout+time.Second)
+	defer cancel()
+	result, err := runner.Check(ctx, immRequest(i, source, "", nil))
+	if err != nil {
+		editInteraction(s, i, "IMMチェックに失敗しました: "+err.Error())
+		return
+	}
+	if result.ExitCode != 0 || result.TimedOut || result.OutputTruncated {
+		editInteraction(s, i, FormatImmFailure("IMMチェックに失敗しました", result))
+		return
+	}
+	editInteraction(s, i, "IMM check OK")
+}
+
+func immRequest(i *discordgo.InteractionCreate, source, rawArgs string, args []string) imm.Request {
+	userID := ""
+	if i.Member != nil && i.Member.User != nil {
+		userID = i.Member.User.ID
+	} else if i.User != nil {
+		userID = i.User.ID
+	}
+	return imm.Request{
+		Source:    source,
+		Args:      args,
+		RawArgs:   rawArgs,
+		UserID:    userID,
+		ChannelID: i.ChannelID,
+		GuildID:   i.GuildID,
+	}
+}
+
+func stringOptionValue(opts []*discordgo.ApplicationCommandInteractionDataOption, name string) string {
+	value := getStringOption(opts, name)
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func deferInteraction(s *discordgo.Session, i *discordgo.InteractionCreate) bool {
+	err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
+	})
+	return err == nil
+}
+
+func editInteraction(s *discordgo.Session, i *discordgo.InteractionCreate, content string) {
+	content = truncateDiscordMessage(content)
+	_, _ = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{Content: &content})
+}
+
+func FormatImmOutput(stdout string) string {
+	out := strings.TrimRight(stdout, "\r\n")
+	if out == "" {
+		return "IMMの出力は空です。"
+	}
+	return truncateDiscordMessage(out)
+}
+
+func FormatImmFailure(prefix string, result imm.Result) string {
+	var parts []string
+	if result.TimedOut {
+		parts = append(parts, "timeout")
+	}
+	if result.OutputTruncated {
+		parts = append(parts, "output truncated")
+	}
+	if result.ExitCode != 0 {
+		parts = append(parts, fmt.Sprintf("exit=%d", result.ExitCode))
+	}
+	detail := strings.TrimSpace(strings.TrimSpace(result.Stderr) + "\n" + strings.TrimSpace(result.Stdout))
+	if detail == "" {
+		detail = strings.Join(parts, ", ")
+	}
+	return truncateDiscordMessage(prefix + "\n```text\n" + truncateForCodeBlock(detail) + "\n```")
+}
+
+func truncateDiscordMessage(content string) string {
+	const limit = 1900
+	if len([]rune(content)) <= limit {
+		return content
+	}
+	runes := []rune(content)
+	return string(runes[:limit]) + "\n...(truncated)"
+}
+
+func truncateForCodeBlock(content string) string {
+	content = strings.ReplaceAll(content, "```", "`\u200b``")
+	return truncateDiscordMessage(content)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,8 @@ package config
 import (
 	"fmt"
 	"os"
+	"strconv"
+	"time"
 
 	"github.com/joho/godotenv"
 )
@@ -17,6 +19,12 @@ type Config struct {
 	// API
 	APIURL   string
 	APIToken string
+
+	// IMM
+	IMMBinaryPath     string
+	IMMTimeout        time.Duration
+	IMMMaxSourceBytes int
+	IMMMaxOutputBytes int
 }
 
 func Load() (*Config, error) {
@@ -24,10 +32,14 @@ func Load() (*Config, error) {
 	_ = godotenv.Load()
 
 	cfg := &Config{
-		DiscordToken: os.Getenv("DISCORD_TOKEN"),
-		DatabaseURL:  os.Getenv("DATABASE_URL"),
-		APIURL:       getEnvDefault("API_URL", "http://localhost:3000"),
-		APIToken:     os.Getenv("API_TOKEN"),
+		DiscordToken:      os.Getenv("DISCORD_TOKEN"),
+		DatabaseURL:       os.Getenv("DATABASE_URL"),
+		APIURL:            getEnvDefault("API_URL", "http://localhost:3000"),
+		APIToken:          os.Getenv("API_TOKEN"),
+		IMMBinaryPath:     getEnvDefault("IMM_BINARY", "imm"),
+		IMMTimeout:        getDurationEnvDefault("IMM_TIMEOUT_MS", 3*time.Second),
+		IMMMaxSourceBytes: getIntEnvDefault("IMM_MAX_SOURCE_BYTES", 64*1024),
+		IMMMaxOutputBytes: getIntEnvDefault("IMM_MAX_OUTPUT_BYTES", 64*1024),
 	}
 
 	if cfg.DiscordToken == "" {
@@ -45,4 +57,28 @@ func getEnvDefault(key, defaultValue string) string {
 		return value
 	}
 	return defaultValue
+}
+
+func getIntEnvDefault(key string, defaultValue int) int {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultValue
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil || parsed <= 0 {
+		return defaultValue
+	}
+	return parsed
+}
+
+func getDurationEnvDefault(key string, defaultValue time.Duration) time.Duration {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultValue
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil || parsed <= 0 {
+		return defaultValue
+	}
+	return time.Duration(parsed) * time.Millisecond
 }

--- a/internal/imm/args.go
+++ b/internal/imm/args.go
@@ -1,0 +1,63 @@
+package imm
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+func SplitArgs(input string) ([]string, error) {
+	var args []string
+	var current strings.Builder
+	var quote rune
+	escaped := false
+	inToken := false
+
+	for _, r := range input {
+		if escaped {
+			current.WriteRune(r)
+			escaped = false
+			inToken = true
+			continue
+		}
+		if r == '\\' {
+			escaped = true
+			inToken = true
+			continue
+		}
+		if quote != 0 {
+			if r == quote {
+				quote = 0
+				continue
+			}
+			current.WriteRune(r)
+			continue
+		}
+		if r == '"' || r == '\'' {
+			quote = r
+			inToken = true
+			continue
+		}
+		if unicode.IsSpace(r) {
+			if inToken {
+				args = append(args, current.String())
+				current.Reset()
+				inToken = false
+			}
+			continue
+		}
+		current.WriteRune(r)
+		inToken = true
+	}
+
+	if escaped {
+		current.WriteRune('\\')
+	}
+	if quote != 0 {
+		return nil, fmt.Errorf("unterminated quote")
+	}
+	if inToken {
+		args = append(args, current.String())
+	}
+	return args, nil
+}

--- a/internal/imm/args_test.go
+++ b/internal/imm/args_test.go
@@ -1,0 +1,64 @@
+package imm
+
+import (
+	"context"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestSplitArgs(t *testing.T) {
+	got, err := SplitArgs(`a 3 "two words" 'and more'`)
+	if err != nil {
+		t.Fatalf("SplitArgs() error = %v", err)
+	}
+	want := []string{"a", "3", "two words", "and more"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("SplitArgs() = %#v, want %#v", got, want)
+	}
+}
+
+func TestRunnerRunWithConfiguredBinary(t *testing.T) {
+	binary := os.Getenv("IMM_TEST_BINARY")
+	if binary == "" {
+		t.Skip("IMM_TEST_BINARY is not set")
+	}
+
+	runner := NewRunner(binary)
+	result, err := runner.Run(context.Background(), Request{
+		Source:  `squeak bot_args[0] + bot_args[0] + bot_args[0]`,
+		Args:    []string{"a"},
+		RawArgs: "a",
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("Run() exit = %d stderr = %s", result.ExitCode, result.Stderr)
+	}
+	if strings.TrimSpace(result.Stdout) != "aaa" {
+		t.Fatalf("Run() stdout = %q, want aaa", result.Stdout)
+	}
+}
+
+func TestBuildSourceWrapsSnippetAndInjectsBotArgs(t *testing.T) {
+	source := BuildSource(Request{
+		Source:  `squeak bot_args[0]`,
+		Args:    []string{"a"},
+		RawArgs: "a",
+		UserID:  "u1",
+	})
+
+	for _, want := range []string{
+		`stash bot_args = ["a"]`,
+		`stash bot_raw = "a"`,
+		`stash bot_user_id = "u1"`,
+		"marmot main {",
+		"    squeak bot_args[0]",
+	} {
+		if !strings.Contains(source, want) {
+			t.Fatalf("BuildSource() missing %q in:\n%s", want, source)
+		}
+	}
+}

--- a/internal/imm/runner.go
+++ b/internal/imm/runner.go
@@ -1,0 +1,382 @@
+package imm
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+const (
+	DefaultTimeout        = 3 * time.Second
+	DefaultMaxSourceBytes = 64 * 1024
+	DefaultMaxOutputBytes = 64 * 1024
+)
+
+type Runner struct {
+	BinaryPath          string
+	Timeout             time.Duration
+	MaxSourceBytes      int
+	MaxOutputBytes      int
+	DisableMacOSSandbox bool
+}
+
+type Request struct {
+	Source    string
+	Args      []string
+	RawArgs   string
+	UserID    string
+	ChannelID string
+	GuildID   string
+	Trace     bool
+}
+
+type Result struct {
+	Stdout          string
+	Stderr          string
+	ExitCode        int
+	TimedOut        bool
+	OutputTruncated bool
+	Duration        time.Duration
+}
+
+func NewRunner(binaryPath string) *Runner {
+	if strings.TrimSpace(binaryPath) == "" {
+		binaryPath = "imm"
+	}
+	return &Runner{
+		BinaryPath:     binaryPath,
+		Timeout:        DefaultTimeout,
+		MaxSourceBytes: DefaultMaxSourceBytes,
+		MaxOutputBytes: DefaultMaxOutputBytes,
+	}
+}
+
+func (r *Runner) Run(ctx context.Context, req Request) (Result, error) {
+	return r.execute(ctx, "run", BuildSource(req), req.Trace)
+}
+
+func (r *Runner) Check(ctx context.Context, req Request) (Result, error) {
+	return r.execute(ctx, "check", BuildSource(req), false)
+}
+
+func BuildSource(req Request) string {
+	prefix := strings.Join([]string{
+		"stash bot_args = " + immArray(req.Args),
+		"stash bot_raw = " + immString(req.RawArgs),
+		"stash bot_user_id = " + immString(req.UserID),
+		"stash bot_channel_id = " + immString(req.ChannelID),
+		"stash bot_guild_id = " + immString(req.GuildID),
+		"",
+	}, "\n")
+
+	source := strings.TrimSpace(stripCodeFence(req.Source))
+	if hasEntrypoint(source) {
+		return prefix + source + "\n"
+	}
+
+	return prefix + "marmot main {\n" + indentSource(source) + "\n}\n"
+}
+
+func stripCodeFence(source string) string {
+	text := strings.TrimSpace(source)
+	if !strings.HasPrefix(text, "```") || !strings.HasSuffix(text, "```") {
+		return source
+	}
+	lines := strings.Split(text, "\n")
+	if len(lines) < 2 {
+		return source
+	}
+	return strings.Join(lines[1:len(lines)-1], "\n")
+}
+
+func hasEntrypoint(source string) bool {
+	return strings.Contains(source, "marmot main")
+}
+
+func indentSource(source string) string {
+	lines := strings.Split(source, "\n")
+	for i, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		lines[i] = "    " + line
+	}
+	return strings.Join(lines, "\n")
+}
+
+func immArray(values []string) string {
+	parts := make([]string, 0, len(values))
+	for _, value := range values {
+		parts = append(parts, immString(value))
+	}
+	return "[" + strings.Join(parts, ", ") + "]"
+}
+
+func immString(value string) string {
+	return strconv.Quote(value)
+}
+
+func (r *Runner) execute(ctx context.Context, mode, source string, trace bool) (Result, error) {
+	started := time.Now()
+	timeout := r.Timeout
+	if timeout <= 0 {
+		timeout = DefaultTimeout
+	}
+	maxSourceBytes := r.MaxSourceBytes
+	if maxSourceBytes <= 0 {
+		maxSourceBytes = DefaultMaxSourceBytes
+	}
+	maxOutputBytes := r.MaxOutputBytes
+	if maxOutputBytes <= 0 {
+		maxOutputBytes = DefaultMaxOutputBytes
+	}
+
+	if strings.TrimSpace(source) == "" {
+		return Result{}, fmt.Errorf("IMM source is required")
+	}
+	if len([]byte(source)) > maxSourceBytes {
+		return Result{}, fmt.Errorf("IMM source must be %d bytes or less", maxSourceBytes)
+	}
+
+	tempDir, err := os.MkdirTemp("", "nkmzbot-imm-")
+	if err != nil {
+		return Result{}, fmt.Errorf("create IMM temp dir: %w", err)
+	}
+	defer os.RemoveAll(tempDir)
+	_ = os.Chmod(tempDir, 0o700)
+
+	sourcePath := filepath.Join(tempDir, "main.imm")
+	if err := os.WriteFile(sourcePath, []byte(source), 0o600); err != nil {
+		return Result{}, fmt.Errorf("write IMM source: %w", err)
+	}
+
+	command, args, err := r.command(tempDir, mode, sourcePath, trace)
+	if err != nil {
+		return Result{}, err
+	}
+
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(runCtx, command, args...)
+	cmd.Dir = tempDir
+	cmd.Env = []string{
+		"PATH=" + os.Getenv("PATH"),
+		"HOME=" + tempDir,
+		"TMPDIR=" + tempDir,
+		"TEMP=" + tempDir,
+		"TMP=" + tempDir,
+		"NO_COLOR=1",
+		"RUST_BACKTRACE=0",
+		"IMM_BOT_SANDBOX=1",
+	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return Result{}, fmt.Errorf("open IMM stdout: %w", err)
+	}
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		return Result{}, fmt.Errorf("open IMM stderr: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return Result{}, fmt.Errorf("start IMM: %w", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-runCtx.Done():
+			killProcessGroup(cmd.Process)
+		case <-done:
+		}
+	}()
+
+	stdout := newLimitBuffer(maxOutputBytes, cancel)
+	stderr := newLimitBuffer(maxOutputBytes, cancel)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go copyOutput(&wg, stdout, stdoutPipe)
+	go copyOutput(&wg, stderr, stderrPipe)
+
+	waitErr := cmd.Wait()
+	close(done)
+	wg.Wait()
+
+	result := Result{
+		Stdout:          stdout.String(),
+		Stderr:          stderr.String(),
+		ExitCode:        -1,
+		TimedOut:        runCtx.Err() == context.DeadlineExceeded,
+		OutputTruncated: stdout.Truncated() || stderr.Truncated(),
+		Duration:        time.Since(started),
+	}
+	if cmd.ProcessState != nil {
+		result.ExitCode = cmd.ProcessState.ExitCode()
+	}
+	if waitErr != nil && result.ExitCode == -1 && !result.TimedOut && !result.OutputTruncated {
+		return result, fmt.Errorf("run IMM: %w", waitErr)
+	}
+	return result, nil
+}
+
+func (r *Runner) command(tempDir, mode, sourcePath string, trace bool) (string, []string, error) {
+	args := []string{mode, sourcePath}
+	if mode == "run" && trace {
+		args = append(args, "--trace")
+	}
+
+	binary := strings.TrimSpace(r.BinaryPath)
+	if binary == "" {
+		binary = "imm"
+	}
+
+	realBinary, err := resolveBinary(binary)
+	if err != nil {
+		return "", nil, err
+	}
+	if runtime.GOOS == "darwin" && !r.DisableMacOSSandbox && canUseMacSandbox() {
+		sandboxBinary := filepath.Join(tempDir, filepath.Base(realBinary))
+		if err := copyFile(realBinary, sandboxBinary, 0o700); err != nil {
+			return "", nil, fmt.Errorf("prepare IMM sandbox binary: %w", err)
+		}
+		profilePath := filepath.Join(tempDir, "sandbox.sb")
+		if err := os.WriteFile(profilePath, []byte(macSandboxProfile(tempDir)), 0o600); err != nil {
+			return "", nil, fmt.Errorf("write IMM sandbox profile: %w", err)
+		}
+		return "/usr/bin/sandbox-exec", append([]string{"-f", profilePath, sandboxBinary}, args...), nil
+	}
+
+	return realBinary, args, nil
+}
+
+func resolveBinary(binary string) (string, error) {
+	if filepath.IsAbs(binary) {
+		return filepath.EvalSymlinks(binary)
+	}
+	path, err := exec.LookPath(binary)
+	if err != nil {
+		return "", fmt.Errorf("IMM binary not found: %s", binary)
+	}
+	return filepath.EvalSymlinks(path)
+}
+
+func canUseMacSandbox() bool {
+	if os.Getenv("IMM_BOT_DISABLE_OS_SANDBOX") == "1" {
+		return false
+	}
+	info, err := os.Stat("/usr/bin/sandbox-exec")
+	return err == nil && !info.IsDir() && info.Mode()&0o111 != 0
+}
+
+func macSandboxProfile(tempDir string) string {
+	homeDir, _ := os.UserHomeDir()
+	return strings.Join([]string{
+		"(version 1)",
+		"(deny default)",
+		"(allow process-exec)",
+		"(allow process-fork)",
+		"(allow signal)",
+		"(allow sysctl-read)",
+		"(allow mach-lookup)",
+		"(allow file-read*)",
+		"(deny file-read* (subpath " + strconv.Quote(homeDir) + "))",
+		"(deny file-read* (subpath " + strconv.Quote("/Users") + "))",
+		"(allow file-read* (subpath " + strconv.Quote(tempDir) + "))",
+		"(allow file-write* (subpath " + strconv.Quote(tempDir) + "))",
+		"(deny network*)",
+		"",
+	}, "\n")
+}
+
+func copyFile(src, dst string, mode os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	if err := out.Close(); err != nil {
+		return err
+	}
+	return os.Chmod(dst, mode)
+}
+
+func killProcessGroup(process *os.Process) {
+	if process == nil {
+		return
+	}
+	if process.Pid > 0 {
+		_ = syscall.Kill(-process.Pid, syscall.SIGKILL)
+	}
+	_ = process.Kill()
+}
+
+type limitBuffer struct {
+	mu        sync.Mutex
+	buf       bytes.Buffer
+	limit     int
+	truncated bool
+	cancel    context.CancelFunc
+}
+
+func newLimitBuffer(limit int, cancel context.CancelFunc) *limitBuffer {
+	return &limitBuffer{limit: limit, cancel: cancel}
+}
+
+func (b *limitBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	remaining := b.limit - b.buf.Len()
+	if remaining <= 0 {
+		b.truncated = true
+		b.cancel()
+		return len(p), nil
+	}
+	if len(p) > remaining {
+		_, _ = b.buf.Write(p[:remaining])
+		b.truncated = true
+		b.cancel()
+		return len(p), nil
+	}
+	_, _ = b.buf.Write(p)
+	return len(p), nil
+}
+
+func (b *limitBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func (b *limitBuffer) Truncated() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.truncated
+}
+
+func copyOutput(wg *sync.WaitGroup, dst io.Writer, src io.Reader) {
+	defer wg.Done()
+	_, _ = io.Copy(dst, src)
+}


### PR DESCRIPTION
## Summary
- Add IMM execution through `/imm run` and `/imm check`.
- Add IMM custom command management with `/imm command add|update|remove`.
- Add the `Run as IMM` message context command.
- Wire bot command lookup to preserve text commands while allowing IMM command execution.

## Validation
- `go test ./...`
- `IMM_TEST_BINARY='/Users/susu/Documents/New project 2/target/debug/imm-native' go test ./internal/imm -run TestRunnerRunWithConfiguredBinary -count=1`
- `git diff --check`