### PR TITLE
[codex] Mount IMM binary in Docker

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,7 +2,10 @@ DISCORD_TOKEN=your_discord_bot_token_here
 DATABASE_URL=postgres://user:password@localhost/nkmzbot
 API_URL=https://api.example.com
 API_TOKEN=your_api_token_here
-IMM_BINARY=imm
+
+# Docker Compose treats this as the host path to the Linux IMM binary and
+# mounts it into the container as /usr/local/bin/imm.
+IMM_BINARY=/usr/local/bin/imm
 IMM_TIMEOUT_MS=3000
 IMM_MAX_SOURCE_BYTES=65536
 IMM_MAX_OUTPUT_BYTES=65536

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -44,7 +44,22 @@ cat ~/.ssh/github_deploy_key
 4. Value: コピーした秘密鍵を貼り付け
 5. Add secret をクリック
 
-## 3. デプロイフロー
+## 3. サーバー側の `.env`
+
+`docker-compose.yml` は `.env` の `IMM_BINARY` をホスト側のLinux IMMバイナリとして
+コンテナ内の `/usr/local/bin/imm` にbind mountします。
+
+```env
+IMM_BINARY=/usr/local/bin/imm
+```
+
+IMMを別の場所に入れている場合は、その絶対パスを指定してください。
+
+```env
+IMM_BINARY=/home/wabu/.cargo/bin/imm-native
+```
+
+## 4. デプロイフロー
 
 ```
 mainブランチにマージ
@@ -64,7 +79,7 @@ docker compose up -d
 デプロイ完了 ✅
 ```
 
-## 4. 動作確認
+## 5. 動作確認
 
 ### 手動で試す場合
 
@@ -85,7 +100,7 @@ docker compose ps
 3. "Deploy" ワークフローが実行されることを確認
 4. ログを確認して成功を確認
 
-## 5. トラブルシューティング
+## 6. トラブルシューティング
 
 ### SSH接続エラーの場合
 
@@ -115,14 +130,14 @@ Name: DEPLOY_PATH
 Value: /path/to/your/nkmzbot
 ```
 
-## 6. セキュリティ注意事項
+## 7. セキュリティ注意事項
 
 - SSH秘密鍵は**絶対に**コミットしない
 - GitHub Secretsに保存した秘密鍵は暗号化されて保存される
 - デプロイ用の鍵は専用のものを使用し、他の用途と混在させない
 - 可能であれば、SSHポートをデフォルトの22から変更することを推奨
 
-## 7. デプロイの無効化
+## 8. デプロイの無効化
 
 自動デプロイを一時的に停止したい場合：
 - リポジトリの Settings → Actions → Disable workflow を選択

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,11 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -o nkmzbot cmd/nkmzbot/main.go
 
 # Runtime stage
-FROM alpine:latest
+FROM ubuntu:24.04
 
-RUN apk --no-cache add ca-certificates
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
@@ -25,6 +27,9 @@ COPY --from=builder /app/nkmzbot .
 
 # Copy migrations
 COPY migrations ./migrations
+
+# docker-compose.yml mounts the host IMM binary here.
+ENV IMM_BINARY=/usr/local/bin/imm
 
 # Run the application
 CMD ["./nkmzbot"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Discord bot for managing custom commands.
 - DATABASE_URL: Postgres 接続文字列
 - API_URL: カスタムコマンド管理APIのURL
 - API_TOKEN: カスタムコマンド管理APIのトークン
-- IMM_BINARY: IMM CLIのパス（省略時 `imm`）
+- IMM_BINARY: IMM CLIのパス（省略時 `imm`）。Docker Composeではホスト側のLinux IMMバイナリの絶対パス
 - IMM_TIMEOUT_MS: IMM実行タイムアウトms（省略時 `3000`）
 - IMM_MAX_SOURCE_BYTES: IMMソース上限（省略時 `65536`）
 - IMM_MAX_OUTPUT_BYTES: IMM出力上限（省略時 `65536`）
@@ -21,13 +21,15 @@ Discord bot for managing custom commands.
 ## Docker
 
 ```bash
-# 例
-DISCORD_TOKEN=... \
-DATABASE_URL=postgres://... \
-API_URL=... \
-API_TOKEN=... \
-go run cmd/nkmzbot/main.go
+cp .env.sample .env
+# .env の IMM_BINARY をサーバー上のLinux IMMバイナリの絶対パスにする
+docker compose build
+docker compose up -d
 ```
+
+Docker Composeでは `.env` の `IMM_BINARY` をホスト側のバイナリとして
+`/usr/local/bin/imm` にbind mountし、botには `IMM_BINARY=/usr/local/bin/imm`
+として渡します。
 
 ## ビルド
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,10 @@ services:
     container_name: nkmzbot
     env_file:
       - .env
+    environment:
+      IMM_BINARY: /usr/local/bin/imm
+    volumes:
+      - ${IMM_BINARY:?Set IMM_BINARY in .env to the host path of the Linux IMM binary}:/usr/local/bin/imm:ro
     ports:
       - "3021:3021"
     restart: always


### PR DESCRIPTION
## Summary
- Mount the host Linux IMM binary into the bot container at `/usr/local/bin/imm`.
- Override the container `IMM_BINARY` value so the bot uses the mounted path instead of a host-only path.
- Switch the runtime image from Alpine to Ubuntu 24.04 to better support glibc-linked Linux IMM binaries.
- Document the `.env` setup for Docker deployments.

## Validation
- `docker compose` config resolution using a temporary `.env`
- `docker build -t nkmzbot:imm-mount-test .`
- `docker run --rm --entrypoint /bin/sh nkmzbot:imm-mount-test -lc 'printf "%s\n" "$IMM_BINARY"; test -d /app/migrations; test -x /app/nkmzbot'`
- `go test ./...`
- `git diff --check`