### PR TITLE
[codex] Add IMM context menu modals

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,8 @@ go build -o nkmzbot cmd/nkmzbot/main.go
 Wallet API への呼び出しでは既存の `API_TOKEN` を使い、操作ユーザーの Discord ID を `X-Discord-User-ID` ヘッダーで渡します。バックエンド側で Discord ID から Wallet 利用者を特定できる必要があります。
 
 登録したコマンドは `!コマンド名` で呼び出せます。IMMコマンドは `!コマンド名 引数...` の形で引数を渡せます。IMM側では `bot_args`、`bot_raw`、`bot_user_id`、`bot_channel_id`、`bot_guild_id` を参照できます。
+
+メッセージ右クリックからは以下を使えます。
+
+- `Run as IMM`: 選択したメッセージ本文をIMMとして実行します。モーダルで引数を入力できます
+- `Register as IMM`: 選択したメッセージ本文をIMMカスタムコマンドとして登録します

--- a/internal/bot/events.go
+++ b/internal/bot/events.go
@@ -256,11 +256,13 @@ func (b *Bot) handleApplicationCommand(s *discordgo.Session, i *discordgo.Intera
 		commands.HandleImm(s, i, b.client, b.immRunner)
 	case "Register as Response":
 		commands.HandleRegisterAsResponse(s, i)
+	case "Register as IMM":
+		commands.HandleRegisterMessageAsIMM(s, i, b.immRunner)
 	case "Run as IMM":
 		commands.HandleRunMessageAsIMM(s, i, b.immRunner)
 	}
 }
 
 func (b *Bot) handleModalSubmit(s *discordgo.Session, i *discordgo.InteractionCreate) {
-	commands.HandleModalSubmit(s, i, b.client)
+	commands.HandleModalSubmit(s, i, b.client, b.immRunner)
 }

--- a/internal/commands/definitions.go
+++ b/internal/commands/definitions.go
@@ -528,6 +528,10 @@ func GetCommands() []*discordgo.ApplicationCommand {
 			Type: discordgo.MessageApplicationCommand,
 		},
 		{
+			Name: "Register as IMM",
+			Type: discordgo.MessageApplicationCommand,
+		},
+		{
 			Name: "Run as IMM",
 			Type: discordgo.MessageApplicationCommand,
 		},

--- a/internal/commands/imm.go
+++ b/internal/commands/imm.go
@@ -44,22 +44,165 @@ func HandleRunMessageAsIMM(s *discordgo.Session, i *discordgo.InteractionCreate,
 		return
 	}
 	data := i.ApplicationCommandData()
-	if data.Resolved == nil || len(data.Resolved.Messages) == 0 {
+	message := selectedResolvedMessage(data)
+	if message == nil {
 		respondText(s, i, "メッセージが見つかりませんでした。")
 		return
 	}
-
-	var message *discordgo.Message
-	for _, msg := range data.Resolved.Messages {
-		message = msg
-		break
-	}
-	if message == nil || strings.TrimSpace(message.Content) == "" {
+	if strings.TrimSpace(message.Content) == "" {
 		respondText(s, i, "IMMとして実行できる本文がありません。")
 		return
 	}
 
-	runImmInteraction(s, i, runner, message.Content, "", false)
+	showRunMessageAsIMMModal(s, i, message.ID)
+}
+
+func HandleRegisterMessageAsIMM(s *discordgo.Session, i *discordgo.InteractionCreate, runner *imm.Runner) {
+	if runner == nil {
+		respondText(s, i, "IMM runner is not configured.")
+		return
+	}
+	data := i.ApplicationCommandData()
+	message := selectedResolvedMessage(data)
+	if message == nil {
+		respondText(s, i, "メッセージが見つかりませんでした。")
+		return
+	}
+	if strings.TrimSpace(message.Content) == "" {
+		respondText(s, i, "IMMコマンドとして登録できる本文がありません。")
+		return
+	}
+
+	showRegisterMessageAsIMMModal(s, i, message.ID)
+}
+
+func showRunMessageAsIMMModal(s *discordgo.Session, i *discordgo.InteractionCreate, messageID string) {
+	_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseModal,
+		Data: &discordgo.InteractionResponseData{
+			CustomID: modalRunMessageAsIMMPrefix + messageID,
+			Title:    "IMMを実行",
+			Components: []discordgo.MessageComponent{
+				discordgo.ActionsRow{
+					Components: []discordgo.MessageComponent{
+						discordgo.TextInput{
+							CustomID:    "imm_args",
+							Label:       "引数",
+							Style:       discordgo.TextInputShort,
+							Placeholder: `例: a "hello world"`,
+							Required:    false,
+							MaxLength:   1000,
+						},
+					},
+				},
+			},
+		},
+	})
+}
+
+func showRegisterMessageAsIMMModal(s *discordgo.Session, i *discordgo.InteractionCreate, messageID string) {
+	_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseModal,
+		Data: &discordgo.InteractionResponseData{
+			CustomID: modalRegisterMessageIMMPrefix + messageID,
+			Title:    "IMMコマンドを登録",
+			Components: []discordgo.MessageComponent{
+				discordgo.ActionsRow{
+					Components: []discordgo.MessageComponent{
+						discordgo.TextInput{
+							CustomID:    "command_name",
+							Label:       "コマンド名",
+							Style:       discordgo.TextInputShort,
+							Placeholder: "例: repeat",
+							Required:    true,
+							MaxLength:   50,
+						},
+					},
+				},
+				discordgo.ActionsRow{
+					Components: []discordgo.MessageComponent{
+						discordgo.TextInput{
+							CustomID:    "tags",
+							Label:       "タグ",
+							Style:       discordgo.TextInputShort,
+							Placeholder: "例: imm utility",
+							Required:    false,
+							MaxLength:   200,
+						},
+					},
+				},
+			},
+		},
+	})
+}
+
+func HandleRunMessageAsIMMModalSubmit(s *discordgo.Session, i *discordgo.InteractionCreate, runner *imm.Runner, data discordgo.ModalSubmitInteractionData) {
+	if runner == nil {
+		respondText(s, i, "IMM runner is not configured.")
+		return
+	}
+	messageID := strings.TrimPrefix(data.CustomID, modalRunMessageAsIMMPrefix)
+	message, err := s.ChannelMessage(i.ChannelID, messageID)
+	if err != nil {
+		respondText(s, i, "メッセージの取得に失敗しました。")
+		return
+	}
+	if strings.TrimSpace(message.Content) == "" {
+		respondText(s, i, "IMMとして実行できる本文がありません。")
+		return
+	}
+
+	runImmInteraction(s, i, runner, message.Content, modalInputValue(data, "imm_args"), false)
+}
+
+func HandleRegisterMessageAsIMMModalSubmit(s *discordgo.Session, i *discordgo.InteractionCreate, cli *client.Client, runner *imm.Runner, data discordgo.ModalSubmitInteractionData) {
+	if runner == nil {
+		respondText(s, i, "IMM runner is not configured.")
+		return
+	}
+	name := strings.TrimPrefix(strings.TrimSpace(modalInputValue(data, "command_name")), "!")
+	if name == "" {
+		respondText(s, i, "コマンド名が入力されていません。")
+		return
+	}
+
+	messageID := strings.TrimPrefix(data.CustomID, modalRegisterMessageIMMPrefix)
+	message, err := s.ChannelMessage(i.ChannelID, messageID)
+	if err != nil {
+		respondText(s, i, "メッセージの取得に失敗しました。")
+		return
+	}
+	source := message.Content
+	if strings.TrimSpace(source) == "" {
+		respondText(s, i, "IMMコマンドとして登録できる本文がありません。")
+		return
+	}
+
+	if !deferInteraction(s, i) {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), runner.Timeout+time.Second)
+	defer cancel()
+	check, err := runner.Check(ctx, immRequest(i, source, "", nil))
+	if err != nil {
+		editInteraction(s, i, "IMMチェックに失敗しました: "+err.Error())
+		return
+	}
+	if check.ExitCode != 0 || check.TimedOut || check.OutputTruncated {
+		editInteraction(s, i, FormatImmFailure("IMMチェックに失敗しました", check))
+		return
+	}
+
+	if err := cli.AddCommandWithKind(i.GuildID, name, source, "imm", parseTags(modalInputValue(data, "tags"))...); err != nil {
+		if client.IsConnectionError(err) {
+			editInteraction(s, i, apiConnectionErrorMessage)
+		} else {
+			editInteraction(s, i, "IMMコマンドの保存に失敗しました: "+err.Error())
+		}
+		return
+	}
+	editInteraction(s, i, fmt.Sprintf("IMMコマンド `!%s` を追加しました。", name))
 }
 
 func handleImmCommandGroup(s *discordgo.Session, i *discordgo.InteractionCreate, cli *client.Client, runner *imm.Runner, group *discordgo.ApplicationCommandInteractionDataOption) {

--- a/internal/commands/response.go
+++ b/internal/commands/response.go
@@ -6,13 +6,21 @@ import (
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/susu3304/nkmzbot/internal/client"
+	"github.com/susu3304/nkmzbot/internal/imm"
+)
+
+const (
+	modalRegisterResponsePrefix   = "reg_resp:"
+	modalRunMessageAsIMMPrefix    = "imm_run_msg:"
+	modalRegisterMessageIMMPrefix = "imm_reg_msg:"
 )
 
 func HandleRegisterAsResponse(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	data := i.ApplicationCommandData()
 
 	// Get the message from the interaction
-	if data.Resolved == nil || len(data.Resolved.Messages) == 0 {
+	message := selectedResolvedMessage(data)
+	if message == nil {
 		s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseChannelMessageWithSource,
 			Data: &discordgo.InteractionResponseData{
@@ -22,14 +30,8 @@ func HandleRegisterAsResponse(s *discordgo.Session, i *discordgo.InteractionCrea
 		return
 	}
 
-	var message *discordgo.Message
-	for _, msg := range data.Resolved.Messages {
-		message = msg
-		break
-	}
-
 	// Show modal to get command name
-	customID := "reg_resp:" + message.ID
+	customID := modalRegisterResponsePrefix + message.ID
 	err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseModal,
 		Data: &discordgo.InteractionResponseData{
@@ -57,27 +59,23 @@ func HandleRegisterAsResponse(s *discordgo.Session, i *discordgo.InteractionCrea
 	}
 }
 
-func HandleModalSubmit(s *discordgo.Session, i *discordgo.InteractionCreate, cli *client.Client) {
+func HandleModalSubmit(s *discordgo.Session, i *discordgo.InteractionCreate, cli *client.Client, runner *imm.Runner) {
 	data := i.ModalSubmitData()
-	if !strings.HasPrefix(data.CustomID, "reg_resp:") {
-		return
+	switch {
+	case strings.HasPrefix(data.CustomID, modalRegisterResponsePrefix):
+		handleRegisterAsResponseModalSubmit(s, i, cli, data)
+	case strings.HasPrefix(data.CustomID, modalRunMessageAsIMMPrefix):
+		HandleRunMessageAsIMMModalSubmit(s, i, runner, data)
+	case strings.HasPrefix(data.CustomID, modalRegisterMessageIMMPrefix):
+		HandleRegisterMessageAsIMMModalSubmit(s, i, cli, runner, data)
 	}
+}
 
+func handleRegisterAsResponseModalSubmit(s *discordgo.Session, i *discordgo.InteractionCreate, cli *client.Client, data discordgo.ModalSubmitInteractionData) {
 	guildID := i.GuildID
-	messageID := strings.TrimPrefix(data.CustomID, "reg_resp:")
+	messageID := strings.TrimPrefix(data.CustomID, modalRegisterResponsePrefix)
 
-	// Get command name from modal
-	var commandName string
-	for _, component := range data.Components {
-		if actionRow, ok := component.(*discordgo.ActionsRow); ok {
-			for _, c := range actionRow.Components {
-				if input, ok := c.(*discordgo.TextInput); ok && input.CustomID == "command_name" {
-					commandName = input.Value
-				}
-			}
-		}
-	}
-
+	commandName := modalInputValue(data, "command_name")
 	if commandName == "" {
 		s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseChannelMessageWithSource,
@@ -128,4 +126,52 @@ func HandleModalSubmit(s *discordgo.Session, i *discordgo.InteractionCreate, cli
 			Content: content,
 		},
 	})
+}
+
+func selectedResolvedMessage(data discordgo.ApplicationCommandInteractionData) *discordgo.Message {
+	if data.Resolved == nil || len(data.Resolved.Messages) == 0 {
+		return nil
+	}
+	for _, msg := range data.Resolved.Messages {
+		return msg
+	}
+	return nil
+}
+
+func modalInputValue(data discordgo.ModalSubmitInteractionData, customID string) string {
+	for _, component := range data.Components {
+		actionRow, ok := asActionsRow(component)
+		if !ok {
+			continue
+		}
+		for _, c := range actionRow.Components {
+			input, ok := asTextInput(c)
+			if ok && input.CustomID == customID {
+				return strings.TrimSpace(input.Value)
+			}
+		}
+	}
+	return ""
+}
+
+func asActionsRow(component discordgo.MessageComponent) (*discordgo.ActionsRow, bool) {
+	switch v := component.(type) {
+	case *discordgo.ActionsRow:
+		return v, true
+	case discordgo.ActionsRow:
+		return &v, true
+	default:
+		return nil, false
+	}
+}
+
+func asTextInput(component discordgo.MessageComponent) (*discordgo.TextInput, bool) {
+	switch v := component.(type) {
+	case *discordgo.TextInput:
+		return v, true
+	case discordgo.TextInput:
+		return &v, true
+	default:
+		return nil, false
+	}
 }

--- a/internal/commands/response_test.go
+++ b/internal/commands/response_test.go
@@ -1,0 +1,47 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+func TestModalInputValue(t *testing.T) {
+	data := discordgo.ModalSubmitInteractionData{
+		Components: []discordgo.MessageComponent{
+			discordgo.ActionsRow{
+				Components: []discordgo.MessageComponent{
+					discordgo.TextInput{CustomID: "command_name", Value: "  repeat  "},
+				},
+			},
+			discordgo.ActionsRow{
+				Components: []discordgo.MessageComponent{
+					discordgo.TextInput{CustomID: "imm_args", Value: ` a "hello world" `},
+				},
+			},
+		},
+	}
+
+	if got := modalInputValue(data, "command_name"); got != "repeat" {
+		t.Fatalf("modalInputValue(command_name) = %q, want repeat", got)
+	}
+	if got := modalInputValue(data, "imm_args"); got != `a "hello world"` {
+		t.Fatalf("modalInputValue(imm_args) = %q", got)
+	}
+	if got := modalInputValue(data, "missing"); got != "" {
+		t.Fatalf("modalInputValue(missing) = %q, want empty", got)
+	}
+}
+
+func TestGetCommandsIncludesIMMContextCommands(t *testing.T) {
+	got := map[string]discordgo.ApplicationCommandType{}
+	for _, cmd := range GetCommands() {
+		got[cmd.Name] = cmd.Type
+	}
+
+	for _, name := range []string{"Run as IMM", "Register as IMM"} {
+		if got[name] != discordgo.MessageApplicationCommand {
+			t.Fatalf("%s type = %v, want MessageApplicationCommand", name, got[name])
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add a `Register as IMM` message context menu command for saving selected message content as an IMM command.
- Change `Run as IMM` to open a modal so users can pass raw args before executing the selected message.
- Route IMM modal submissions through the existing runner/client flow and add coverage for modal input parsing and context command registration.
- Document the new right-click IMM actions.

## Validation
- `go test ./...`
- `go build -o /tmp/nkmzbot-imm-context-modal ./cmd/nkmzbot`
- `git diff --check`