### PR TITLE
[codex] Separate IMM command prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ go build -o nkmzbot cmd/nkmzbot/main.go
 - `/remove` - コマンドを削除
   - `name`: コマンド名
 - `/list` - 登録されているコマンド一覧を表示
-- `/ramdom` - 登録されているコマンドからランダムに1つ返答
+- `/ramdom` - 登録されている通常コマンドからランダムに1つ返答（IMMコマンドは対象外）
 - `/imm run` - IMMコードをその場で実行
 - `/imm check` - IMMコードを構文チェック
 - `/imm command add|update|remove` - IMMカスタムコマンドを管理
@@ -74,7 +74,7 @@ go build -o nkmzbot cmd/nkmzbot/main.go
 
 Wallet API への呼び出しでは既存の `API_TOKEN` を使い、操作ユーザーの Discord ID を `X-Discord-User-ID` ヘッダーで渡します。バックエンド側で Discord ID から Wallet 利用者を特定できる必要があります。
 
-登録したコマンドは `!コマンド名` で呼び出せます。IMMコマンドは `!コマンド名 引数...` の形で引数を渡せます。IMM側では `bot_args`、`bot_raw`、`bot_user_id`、`bot_channel_id`、`bot_guild_id` を参照できます。
+登録した通常コマンドは `!コマンド名` で呼び出せます。IMMコマンドは `?コマンド名 引数...` の形で呼び出し、引数を渡せます。IMM側では `bot_args`、`bot_raw`、`bot_user_id`、`bot_channel_id`、`bot_guild_id` を参照できます。
 
 メッセージ右クリックからは以下を使えます。
 

--- a/internal/bot/events.go
+++ b/internal/bot/events.go
@@ -15,6 +15,11 @@ import (
 	"github.com/susu3304/nkmzbot/internal/imm"
 )
 
+const (
+	textCommandKind = "text"
+	immCommandKind  = "imm"
+)
+
 func (b *Bot) onReady(s *discordgo.Session, event *discordgo.Ready) {
 	log.Printf("%s is connected!", event.User.Username)
 
@@ -52,16 +57,20 @@ func (b *Bot) onMessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) 
 	}
 
 	content := strings.TrimSpace(m.Content)
-	if strings.HasPrefix(content, "!") && len(content) > 1 {
-		commandText := strings.TrimSpace(content[1:])
-		if m.GuildID != "" {
-			b.handleCustomCommandMessage(s, m, commandText)
-		}
+	if m.GuildID == "" {
+		return
+	}
+
+	switch {
+	case strings.HasPrefix(content, "!") && len(content) > 1:
+		b.handleCustomCommandMessage(s, m, strings.TrimSpace(content[1:]), textCommandKind)
+	case strings.HasPrefix(content, "?") && len(content) > 1:
+		b.handleCustomCommandMessage(s, m, strings.TrimSpace(content[1:]), immCommandKind)
 	}
 }
 
-func (b *Bot) handleCustomCommandMessage(s *discordgo.Session, m *discordgo.MessageCreate, commandText string) {
-	cmdName, cmd, rawArgs, args, err := b.lookupMessageCommand(m.GuildID, commandText)
+func (b *Bot) handleCustomCommandMessage(s *discordgo.Session, m *discordgo.MessageCreate, commandText, expectedKind string) {
+	cmdName, cmd, rawArgs, args, err := b.lookupMessageCommand(m.GuildID, commandText, expectedKind)
 	if err != nil || cmd == nil {
 		return
 	}
@@ -85,12 +94,12 @@ func (b *Bot) handleCustomCommandMessage(s *discordgo.Session, m *discordgo.Mess
 	}
 }
 
-func (b *Bot) lookupMessageCommand(guildID, commandText string) (string, *client.BotCommandResponse, string, []string, error) {
+func (b *Bot) lookupMessageCommand(guildID, commandText, expectedKind string) (string, *client.BotCommandResponse, string, []string, error) {
 	cmd, err := b.client.GetCommand(guildID, commandText)
 	if err != nil {
 		return "", nil, "", nil, err
 	}
-	if cmd != nil {
+	if commandKindMatches(cmd, expectedKind) {
 		return commandText, cmd, "", nil, nil
 	}
 
@@ -102,11 +111,28 @@ func (b *Bot) lookupMessageCommand(guildID, commandText string) (string, *client
 	if err != nil || cmd == nil {
 		return "", nil, "", nil, err
 	}
+	if !commandKindMatches(cmd, expectedKind) {
+		return "", nil, "", nil, nil
+	}
+	if !strings.EqualFold(expectedKind, immCommandKind) {
+		return name, cmd, "", nil, nil
+	}
 	args, err := imm.SplitArgs(rawArgs)
 	if err != nil {
 		return "", nil, "", nil, err
 	}
 	return name, cmd, rawArgs, args, nil
+}
+
+func commandKindMatches(cmd *client.BotCommandResponse, expectedKind string) bool {
+	if cmd == nil {
+		return false
+	}
+	kind := cmd.Kind
+	if kind == "" {
+		kind = textCommandKind
+	}
+	return strings.EqualFold(kind, expectedKind)
 }
 
 func splitCommandText(commandText string) (string, string) {

--- a/internal/bot/events_test.go
+++ b/internal/bot/events_test.go
@@ -1,0 +1,19 @@
+package bot
+
+import (
+	"testing"
+
+	"github.com/susu3304/nkmzbot/internal/client"
+)
+
+func TestCommandKindMatchesDefaultsToText(t *testing.T) {
+	if !commandKindMatches(&client.BotCommandResponse{}, textCommandKind) {
+		t.Fatal("empty command kind should match text")
+	}
+	if commandKindMatches(&client.BotCommandResponse{}, immCommandKind) {
+		t.Fatal("empty command kind should not match imm")
+	}
+	if !commandKindMatches(&client.BotCommandResponse{Kind: "IMM"}, immCommandKind) {
+		t.Fatal("IMM command kind should match case-insensitively")
+	}
+}

--- a/internal/commands/definitions.go
+++ b/internal/commands/definitions.go
@@ -57,7 +57,7 @@ func GetCommands() []*discordgo.ApplicationCommand {
 								{
 									Type:        discordgo.ApplicationCommandOptionString,
 									Name:        "name",
-									Description: "コマンド名（!は不要）",
+									Description: "コマンド名（?は不要）",
 									Required:    true,
 								},
 								{

--- a/internal/commands/imm.go
+++ b/internal/commands/imm.go
@@ -160,7 +160,7 @@ func HandleRegisterMessageAsIMMModalSubmit(s *discordgo.Session, i *discordgo.In
 		respondText(s, i, "IMM runner is not configured.")
 		return
 	}
-	name := strings.TrimPrefix(strings.TrimSpace(modalInputValue(data, "command_name")), "!")
+	name := normalizeImmCommandName(modalInputValue(data, "command_name"))
 	if name == "" {
 		respondText(s, i, "コマンド名が入力されていません。")
 		return
@@ -202,7 +202,7 @@ func HandleRegisterMessageAsIMMModalSubmit(s *discordgo.Session, i *discordgo.In
 		}
 		return
 	}
-	editInteraction(s, i, fmt.Sprintf("IMMコマンド `!%s` を追加しました。", name))
+	editInteraction(s, i, fmt.Sprintf("IMMコマンド `?%s` を追加しました。", name))
 }
 
 func handleImmCommandGroup(s *discordgo.Session, i *discordgo.InteractionCreate, cli *client.Client, runner *imm.Runner, group *discordgo.ApplicationCommandInteractionDataOption) {
@@ -214,7 +214,7 @@ func handleImmCommandGroup(s *discordgo.Session, i *discordgo.InteractionCreate,
 	sub := group.Options[0]
 	switch sub.Name {
 	case "add", "update":
-		name := strings.TrimPrefix(strings.TrimSpace(stringOptionValue(sub.Options, "name")), "!")
+		name := normalizeImmCommandName(stringOptionValue(sub.Options, "name"))
 		source := stringOptionValue(sub.Options, "source")
 		tags := parseTags(stringOptionValue(sub.Options, "tags"))
 		if name == "" || strings.TrimSpace(source) == "" {
@@ -255,9 +255,9 @@ func handleImmCommandGroup(s *discordgo.Session, i *discordgo.InteractionCreate,
 		if sub.Name == "update" {
 			action = "更新"
 		}
-		editInteraction(s, i, fmt.Sprintf("IMMコマンド `!%s` を%sしました。", name, action))
+		editInteraction(s, i, fmt.Sprintf("IMMコマンド `?%s` を%sしました。", name, action))
 	case "remove":
-		name := strings.TrimPrefix(strings.TrimSpace(stringOptionValue(sub.Options, "name")), "!")
+		name := normalizeImmCommandName(stringOptionValue(sub.Options, "name"))
 		if name == "" {
 			respondText(s, i, "nameが必要です。")
 			return
@@ -271,10 +271,14 @@ func handleImmCommandGroup(s *discordgo.Session, i *discordgo.InteractionCreate,
 			}
 			return
 		}
-		respondText(s, i, fmt.Sprintf("IMMコマンド `!%s` を削除しました。", name))
+		respondText(s, i, fmt.Sprintf("IMMコマンド `?%s` を削除しました。", name))
 	default:
 		respondText(s, i, "未知のIMM commandサブコマンドです。")
 	}
+}
+
+func normalizeImmCommandName(name string) string {
+	return strings.TrimSpace(strings.TrimLeft(strings.TrimSpace(name), "!?"))
 }
 
 func runImmInteraction(s *discordgo.Session, i *discordgo.InteractionCreate, runner *imm.Runner, source, rawArgs string, trace bool) {

--- a/internal/commands/imm_test.go
+++ b/internal/commands/imm_test.go
@@ -1,0 +1,16 @@
+package commands
+
+import "testing"
+
+func TestNormalizeImmCommandNameTrimsPrefixes(t *testing.T) {
+	for input, want := range map[string]string{
+		"repeat":    "repeat",
+		"?repeat":   "repeat",
+		"!repeat":   "repeat",
+		"  ?repeat": "repeat",
+	} {
+		if got := normalizeImmCommandName(input); got != want {
+			t.Fatalf("normalizeImmCommandName(%q) = %q, want %q", input, got, want)
+		}
+	}
+}

--- a/internal/commands/list.go
+++ b/internal/commands/list.go
@@ -37,7 +37,7 @@ func HandleList(s *discordgo.Session, i *discordgo.InteractionCreate, cli *clien
 	// Build command list
 	var entries []string
 	for _, cmd := range commands {
-		entries = append(entries, fmt.Sprintf("!%s: %s", cmd.Name, cmd.Response))
+		entries = append(entries, fmt.Sprintf("%s%s: %s", commandPrefix(cmd), cmd.Name, cmd.Response))
 	}
 
 	// Split into 2000 character chunks
@@ -63,4 +63,11 @@ func HandleList(s *discordgo.Session, i *discordgo.InteractionCreate, cli *clien
 			Content: "コマンド一覧を送信しました。",
 		},
 	})
+}
+
+func commandPrefix(cmd client.CommandRecord) string {
+	if strings.EqualFold(strings.TrimSpace(cmd.Kind), "imm") {
+		return "?"
+	}
+	return "!"
 }

--- a/internal/commands/list_test.go
+++ b/internal/commands/list_test.go
@@ -1,0 +1,28 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/susu3304/nkmzbot/internal/client"
+)
+
+func TestCommandPrefix(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  client.CommandRecord
+		want string
+	}{
+		{name: "text", cmd: client.CommandRecord{Kind: "text"}, want: "!"},
+		{name: "legacy", cmd: client.CommandRecord{}, want: "!"},
+		{name: "imm", cmd: client.CommandRecord{Kind: "imm"}, want: "?"},
+		{name: "imm uppercase", cmd: client.CommandRecord{Kind: "IMM"}, want: "?"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := commandPrefix(tt.cmd); got != tt.want {
+				t.Fatalf("commandPrefix() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/commands/random.go
+++ b/internal/commands/random.go
@@ -26,6 +26,7 @@ func HandleRandom(s *discordgo.Session, i *discordgo.InteractionCreate, cli *cli
 		return
 	}
 
+	commands = filterRandomEligibleCommands(commands)
 	commands = filterCommandsByTag(commands, tag)
 	command, ok := pickRandomCommand(commands)
 	if !ok {
@@ -48,6 +49,17 @@ func HandleRandom(s *discordgo.Session, i *discordgo.InteractionCreate, cli *cli
 			Content: command.Response,
 		},
 	})
+}
+
+func filterRandomEligibleCommands(commands []client.CommandRecord) []client.CommandRecord {
+	filtered := make([]client.CommandRecord, 0, len(commands))
+	for _, cmd := range commands {
+		if strings.EqualFold(strings.TrimSpace(cmd.Kind), "imm") {
+			continue
+		}
+		filtered = append(filtered, cmd)
+	}
+	return filtered
 }
 
 func pickRandomCommand(commands []client.CommandRecord) (client.CommandRecord, bool) {

--- a/internal/commands/random_test.go
+++ b/internal/commands/random_test.go
@@ -62,3 +62,19 @@ func TestFilterCommandsByTagEmptyTagKeepsAllCommands(t *testing.T) {
 		t.Fatalf("filterCommandsByTag(empty) returned %d commands, want %d", len(got), len(commands))
 	}
 }
+
+func TestFilterRandomEligibleCommandsDropsIMM(t *testing.T) {
+	commands := []client.CommandRecord{
+		{Name: "hello", Kind: "text", Response: "Hello"},
+		{Name: "repeat", Kind: "imm", Response: "squeak bot_args[0]"},
+		{Name: "legacy", Response: "No kind"},
+	}
+
+	got := filterRandomEligibleCommands(commands)
+	if len(got) != 2 {
+		t.Fatalf("filterRandomEligibleCommands() returned %d commands, want 2", len(got))
+	}
+	if got[0].Name != "hello" || got[1].Name != "legacy" {
+		t.Fatalf("filterRandomEligibleCommands() names = [%q, %q], want [hello, legacy]", got[0].Name, got[1].Name)
+	}
+}


### PR DESCRIPTION
## Summary
- Keep normal custom commands on the `!` prefix and move IMM command execution to the `?` prefix.
- Ensure `!name` only runs text commands and `?name args...` only runs IMM commands.
- Show `?` for IMM entries in `/list` and update IMM command success messages/docs.
- Exclude IMM commands from `/ramdom` selection.

## Validation
- `go test ./...`
- `go build -o /tmp/nkmzbot-separate-imm-prefix ./cmd/nkmzbot`
- `git diff --check`